### PR TITLE
UUID assignment fails.

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -130,7 +130,7 @@ sudo make install
 
 # All done. Generate a UUID for this machine; this is used later in results
 # reporting.
-MAAT_INSTANCE_UUID = $(cat /proc/sys/kernel/random/uuid)
+MAAT_INSTANCE_UUID=$(cat /proc/sys/kernel/random/uuid)
 export MAAT_INSTANCE_UUID
 
 # @todo: Wildcard DNS for *.benchmark


### PR DESCRIPTION
The last 4 lines of execution of the provision.sh script out this:

```
++ cat /proc/sys/kernel/random/uuid
+ MAAT_INSTANCE_UUID = 16c005e7-8a98-41fb-b0d7-e0218ceb1ed3
./maat/scripts/provision.sh: line 133: MAAT_INSTANCE_UUID: command not found
+ export MAAT_INSTANCE_UUID
```

The intended variable `MAAT_INSTANCE_UUID` isn't created because in Bash assignment of variables cannot include spaces.
